### PR TITLE
(cube, lcube) Fixed the calculation of the null space vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `cube, lcube, cubestratified, lcubestratified` error regarding calculation of vectors in null space.
 
 ## [2.0.5] - 2024-02-09
 ### Added

--- a/src/CubeClass.cc
+++ b/src/CubeClass.cc
@@ -12,6 +12,7 @@
 #include "ReducedRowEchelonForm.h"
 #include "uniform.h"
 #include "utils.h"
+#include "utils-matrix.h"
 
 //**********************************************
 // Author: Wilmer Prentius
@@ -97,8 +98,8 @@ void Cube::Init(
     }
 
     for (size_t k = 0; k < pbalance; k++)
-      amat[MatrixIdxRow(k, i, N)] =
-        xxbalance[MatrixIdxCol(i, k, pbalance)] / probabilities[i];
+      amat[MatrixIdxRM(k, i, N)] =
+        xxbalance[MatrixIdxCM(i, k, pbalance)] / probabilities[i];
   }
 
   return;
@@ -245,7 +246,7 @@ void Cube::RunUpdate() {
     if (i == maxSize - 1) {
       uvec[i] = 1.0;
     } else {
-      uvec[i] = -bmat[MatrixIdxRow(i, maxSize - 1, maxSize)];
+      uvec[i] = -bmat[MatrixIdxRM(i, maxSize - 1, maxSize)];
     }
 
     double lval1 = std::abs(probabilities[candidates[i]] / uvec[i]);
@@ -297,7 +298,7 @@ void Cube::RunFlight() {
     // Prepare bmat
     for (size_t i = 0; i < maxSize; i++) {
       for (size_t k = 0; k < maxSize - 1; k++) {
-        bmat[MatrixIdxRow(k, i, maxSize)] = amat[MatrixIdxRow(k, candidates[i], N)];
+        bmat[MatrixIdxRM(k, i, maxSize)] = amat[MatrixIdxRM(k, candidates[i], N)];
       }
     }
 
@@ -323,7 +324,7 @@ void Cube::RunLanding() {
       candidates.push_back(id);
 
       for (size_t k = 0; k < maxSize - 1; k++) {
-        bmat[MatrixIdxRow(k, i, maxSize)] = amat[MatrixIdxRow(k, id, N)];
+        bmat[MatrixIdxRM(k, i, maxSize)] = amat[MatrixIdxRM(k, id, N)];
       }
     }
 

--- a/src/CubeStratifiedClass.cc
+++ b/src/CubeStratifiedClass.cc
@@ -155,10 +155,10 @@ void CubeStratified::RunFlightPerStratum() {
 
       cube.probabilities[indexSize] = r_prob[id];
 
-      cube.amat[MatrixIdxRM((size_t)0, indexSize, it->second)] = 1.0;
+      cube.amat[MatrixIdxCM(indexSize, (size_t)0, it->second)] = 1.0;
 
       for (size_t k = 0; k < pbalance; k++)
-        cube.amat[MatrixIdxRM(k + 1, indexSize, it->second)] =
+        cube.amat[MatrixIdxCM(indexSize, k + 1, it->second)] =
           r_xbalance[MatrixIdxCM(id, k, N)] / r_prob[id];
 
       if (cubeMethod == CubeMethod::lcube) {
@@ -232,10 +232,10 @@ void CubeStratified::RunFlightOnFull() {
     cube.probabilities[indexSize] = probabilities[id];
 
     for (size_t k = 0; k < strsize; k++)
-      cube.amat[MatrixIdxRM(k, indexSize, idxlen)] = (r_strata[id] == stratumArr[k]) ? 1.0 : 0.0;
+      cube.amat[MatrixIdxCM(indexSize, k, idxlen)] = (r_strata[id] == stratumArr[k]) ? 1.0 : 0.0;
 
     for (size_t k = 0; k < pbalance; k++)
-      cube.amat[MatrixIdxRM(strsize + k, indexSize, idxlen)]
+      cube.amat[MatrixIdxCM(indexSize, strsize + k, idxlen)]
         = r_xbalance[MatrixIdxCM(id, k, N)] / r_prob[id];
 
     if (cubeMethod == CubeMethod::lcube) {
@@ -298,10 +298,10 @@ void CubeStratified::RunLandingPerStratum() {
       tidx->Set(indexSize);
       cube.probabilities[indexSize] = probabilities[id];
 
-      cube.amat[MatrixIdxRM((size_t)0, indexSize, it->second)] = 1.0;
+      cube.amat[MatrixIdxCM(indexSize, (size_t)0, it->second)] = 1.0;
 
       for (size_t k = 0; k < pbalance; k++)
-        cube.amat[MatrixIdxRM(k + 1, indexSize, it->second)] =
+        cube.amat[MatrixIdxCM(indexSize, k + 1, it->second)] =
           r_xbalance[MatrixIdxCM(id, k, N)] / probabilities[id];
     }
 

--- a/src/CubeStratifiedClass.cc
+++ b/src/CubeStratifiedClass.cc
@@ -8,6 +8,7 @@
 #include "IndexListClass.h"
 #include "KDTreeClass.h"
 #include "utils.h"
+#include "utils-matrix.h"
 
 // CUBE
 CubeStratified::CubeStratified(
@@ -154,15 +155,15 @@ void CubeStratified::RunFlightPerStratum() {
 
       cube.probabilities[indexSize] = r_prob[id];
 
-      cube.amat[MatrixIdxRow((size_t)0, indexSize, it->second)] = 1.0;
+      cube.amat[MatrixIdxRM((size_t)0, indexSize, it->second)] = 1.0;
 
       for (size_t k = 0; k < pbalance; k++)
-        cube.amat[MatrixIdxRow(k + 1, indexSize, it->second)] =
-          r_xbalance[MatrixIdxCol(id, k, N)] / r_prob[id];
+        cube.amat[MatrixIdxRM(k + 1, indexSize, it->second)] =
+          r_xbalance[MatrixIdxCM(id, k, N)] / r_prob[id];
 
       if (cubeMethod == CubeMethod::lcube) {
         for (size_t k = 0; k < pspread; k++)
-          zspread.push_back(r_xspread[MatrixIdxRow(id, k, pspread)]);
+          zspread.push_back(r_xspread[MatrixIdxRM(id, k, pspread)]);
       }
     }
 
@@ -231,15 +232,15 @@ void CubeStratified::RunFlightOnFull() {
     cube.probabilities[indexSize] = probabilities[id];
 
     for (size_t k = 0; k < strsize; k++)
-      cube.amat[MatrixIdxRow(k, indexSize, idxlen)] = (r_strata[id] == stratumArr[k]) ? 1.0 : 0.0;
+      cube.amat[MatrixIdxRM(k, indexSize, idxlen)] = (r_strata[id] == stratumArr[k]) ? 1.0 : 0.0;
 
     for (size_t k = 0; k < pbalance; k++)
-      cube.amat[MatrixIdxRow(strsize + k, indexSize, idxlen)]
-        = r_xbalance[MatrixIdxCol(id, k, N)] / r_prob[id];
+      cube.amat[MatrixIdxRM(strsize + k, indexSize, idxlen)]
+        = r_xbalance[MatrixIdxCM(id, k, N)] / r_prob[id];
 
     if (cubeMethod == CubeMethod::lcube) {
       for (size_t k = 0; k < pspread; k++)
-        zspread.push_back(r_xspread[MatrixIdxRow(id, k, pspread)]);
+        zspread.push_back(r_xspread[MatrixIdxRM(id, k, pspread)]);
     }
   }
 
@@ -297,11 +298,11 @@ void CubeStratified::RunLandingPerStratum() {
       tidx->Set(indexSize);
       cube.probabilities[indexSize] = probabilities[id];
 
-      cube.amat[MatrixIdxRow((size_t)0, indexSize, it->second)] = 1.0;
+      cube.amat[MatrixIdxRM((size_t)0, indexSize, it->second)] = 1.0;
 
       for (size_t k = 0; k < pbalance; k++)
-        cube.amat[MatrixIdxRow(k + 1, indexSize, it->second)] =
-          r_xbalance[MatrixIdxCol(id, k, N)] / probabilities[id];
+        cube.amat[MatrixIdxRM(k + 1, indexSize, it->second)] =
+          r_xbalance[MatrixIdxCM(id, k, N)] / probabilities[id];
     }
 
     cube.RunLanding();

--- a/src/CubeVectorInNullSpace.cc
+++ b/src/CubeVectorInNullSpace.cc
@@ -1,0 +1,52 @@
+#include <stddef.h>
+#include <stdexcept>
+
+#include "CubeVectorInNullSpace.h"
+#include "utils-matrix.h"
+
+// res_vec assumed to have length (ncolumns)
+// mat Matrix assumed to be in Row Major form, dimensions (ncolumns-1) * (ncolumns)
+void CubeVectorInNullSpace(
+  double *res_vec,
+  double *mat,
+  const size_t ncolumns
+) {
+  size_t nrows = ncolumns - 1;
+  if (ncolumns < 2) {
+    throw std::range_error("nrows and ncolumns must be >= 2");
+  }
+  if (mat[MatrixIdxRM((size_t)0, (size_t)0, ncolumns)] == 0.0) {
+    throw std::range_error("no null basis exists");
+  }
+
+  // If the obs. are linearly independent, we can take the fast route
+  if (mat[MatrixIdxRM(nrows-1, nrows-1, ncolumns)] == 1.0) {
+    res_vec[ncolumns-1] = 1.0;
+
+    for (size_t i = 0; i < nrows; i++) {
+      res_vec[i] = -mat[MatrixIdxRM(i, ncolumns-1, ncolumns)];
+    }
+
+    return;
+  }
+
+  // If any obs is linearly dependent, we must take the slow route
+  // We can assume that the first entry in mat is 1.0
+  for (size_t k = 1; k < ncolumns; k++) res_vec[k] = (k % 2 == 0) ? -1.0 : 1.0;
+
+  for (size_t i = 0; i < nrows; i++) {
+    size_t lead = 0;
+
+    for (; lead < ncolumns; lead++) {
+      if (mat[MatrixIdxRM(i, lead, ncolumns)] == 1.0) break;
+    }
+
+    if (lead >= ncolumns) continue;
+
+    res_vec[lead] = 0.0;
+    for (size_t k = lead + 1; k < ncolumns; k++) {
+      res_vec[lead] -= res_vec[k] * mat[MatrixIdxRM(i, k, ncolumns)];
+    }
+  }
+}
+

--- a/src/CubeVectorInNullSpace.h
+++ b/src/CubeVectorInNullSpace.h
@@ -1,0 +1,13 @@
+#ifndef CUBEVECTORINNULLSPACE_HEADER
+#define CUBEVECTORINNULLSPACE_HEADER
+
+#include <stddef.h>
+
+void CubeVectorInNullSpace(
+  double *res_vec,
+  double *mat,
+  const size_t ncolumns
+);
+
+#endif
+

--- a/src/KDTreeClass.cc
+++ b/src/KDTreeClass.cc
@@ -7,8 +7,8 @@
 
 #include "KDNodeClass.h"
 #include "KDStoreClass.h"
-#include "utils.h"
 #include "KDTreeClass.h"
+#include "utils-matrix.h"
 
 KDTreeSplitMethod IntToKDTreeSplitMethod(const int i) {
   if (0 <= i && i <= 2)
@@ -176,7 +176,7 @@ size_t KDTree::SplitByVariable(KDNode* node, size_t* splitUnits, const size_t n)
 
   // n >> 1 tries to split the units by the median
   size_t m = SplitUnitsById(splitUnits, n, n >> 1, node->split);
-  node->value = data[MatrixIdxRow(splitUnits[m - 1], node->split, p)];
+  node->value = data[MatrixIdxRM(splitUnits[m - 1], node->split, p)];
 
   return m;
 }
@@ -223,7 +223,7 @@ size_t KDTree::SplitByMaximalSpread(KDNode* node, size_t* splitUnits, const size
 
   // Find the median unit for splitting
   size_t m = SplitUnitsById(splitUnits, n, n >> 1, node->split);
-  node->value = data[MatrixIdxRow(splitUnits[m - 1], node->split, p)];
+  node->value = data[MatrixIdxRM(splitUnits[m - 1], node->split, p)];
   return m;
 }
 

--- a/src/ReducedRowEchelonForm.cc
+++ b/src/ReducedRowEchelonForm.cc
@@ -1,40 +1,40 @@
 #include <stddef.h>
 
 #include "ReducedRowEchelonForm.h"
-#include "utils.h"
+#include "utils-matrix.h"
 
 void ReducedRowEchelonForm(
   double *mat,
-  const size_t rowCount,
-  const size_t colCount
+  const size_t nrows,
+  const size_t ncolumns
 ) {
   size_t lead = 0;
 
-  for (size_t r = 0; r < rowCount; r++) {
-    if (colCount <= lead)
+  for (size_t r = 0; r < nrows; r++) {
+    if (ncolumns <= lead)
       return;
 
     size_t i = r;
 
-    while (mat[MatrixIdx(i, lead, colCount)] == 0) {
+    while (mat[MatrixIdxRM(i, lead, ncolumns)] == 0.0) {
       i += 1;
 
-      if (i == rowCount) {
+      if (i == nrows) {
         i = r;
         lead += 1;
 
-        if (colCount == lead)
+        if (ncolumns == lead)
           return;
       }
     }
 
-    double *br = mat + MatrixIdx(r, (size_t)0, colCount);
+    double *br = mat + MatrixIdxRM(r, (size_t)0, ncolumns);
 
     if (i != r) {
-      double *bi = mat + MatrixIdx(i, (size_t)0, colCount);
+      double *bi = mat + MatrixIdxRM(i, (size_t)0, ncolumns);
 
       // Swap rows
-      for (size_t k = 0; k < colCount; k++) {
+      for (size_t k = 0; k < ncolumns; k++) {
         double temp = bi[k];
         bi[k] = br[k];
         br[k] = temp;
@@ -45,20 +45,20 @@ void ReducedRowEchelonForm(
     /*if (br[lead] != 0.0)*/ {
       double temp = br[lead];
       br[lead] = 1.0;
-      for (size_t k = lead + 1; k < colCount; k++) {
+      for (size_t k = lead + 1; k < ncolumns; k++) {
         br[k] /= temp;
       }
     }
 
     // Remove row r from all outher rows
-    for (size_t j = 0; j < rowCount; j++) {
+    for (size_t j = 0; j < nrows; j++) {
       if (j == r)
         continue;
 
-      double temp = mat[MatrixIdx(j, lead, colCount)];
-      mat[MatrixIdx(j, lead, colCount)] = 0.0;
-      for (size_t k = lead + 1; k < colCount; k++) {
-        mat[MatrixIdx(j, k, colCount)] -= br[k] * temp;
+      double temp = mat[MatrixIdxRM(j, lead, ncolumns)];
+      mat[MatrixIdxRM(j, lead, ncolumns)] = 0.0;
+      for (size_t k = lead + 1; k < ncolumns; k++) {
+        mat[MatrixIdxRM(j, k, ncolumns)] -= br[k] * temp;
       }
     }
 

--- a/src/ReducedRowEchelonForm.h
+++ b/src/ReducedRowEchelonForm.h
@@ -5,8 +5,9 @@
 
 void ReducedRowEchelonForm(
   double *mat,
-  const size_t rowCount,
-  const size_t colCount
+  const size_t nrows,
+  const size_t ncolumns
 );
 
 #endif
+

--- a/src/utils-matrix.h
+++ b/src/utils-matrix.h
@@ -1,0 +1,23 @@
+#ifndef BSUTILS_MATRIX_HEADER
+#define BSUTILS_MATRIX_HEADER
+
+#include <stddef.h>
+
+// ROW MAJOR
+inline int MatrixIdxRM(int row, int col, int pcols) {
+  return row * pcols + col;
+}
+inline size_t MatrixIdxRM(size_t row, size_t col, size_t pcols) {
+  return row * pcols + col;
+}
+
+// COL MAJOR
+inline int MatrixIdxCM(int row, int col, int nrows) {
+  return col * nrows + row;
+}
+inline size_t MatrixIdxCM(size_t row, size_t col, size_t nrows) {
+  return col * nrows + row;
+}
+
+#endif
+

--- a/src/utils.h
+++ b/src/utils.h
@@ -24,23 +24,4 @@ inline bool ProbabilityInt(size_t p, size_t N) {
   return (p) == (0) || (p) == (N);
 };
 
-inline int MatrixIdx(int row, int col, int pcols) {
-  return (row) * (pcols) + (col);
-}
-inline size_t MatrixIdx(size_t row, size_t col, size_t pcols) {
-  return (row) * (pcols) + (col);
-}
-inline int MatrixIdxRow(int row, int col, int pcols) {
-  return (row) * (pcols) + (col);
-}
-inline size_t MatrixIdxRow(size_t row, size_t col, size_t pcols) {
-  return (row) * (pcols) + (col);
-}
-inline int MatrixIdxCol(int row, int col, int nrows) {
-  return (col) * (nrows) + (row);
-}
-inline size_t MatrixIdxCol(size_t row, size_t col, size_t nrows) {
-  return (col) * (nrows) + (row);
-}
-
 #endif


### PR DESCRIPTION
- Fixed calculation of null space vectors for matrices with dependencies between rows.
- Moved inline matrix index functions to an own file, and changed the major order within cube methods.