### PR TITLE
Bugs affecting cube methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - fixed bug in `cube`.
+- fixed bug in `IndexList`.
 
 ## [2.0.6] - 2024-02-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- `cube, lcube, cubestratified, lcubestratified` error regarding calculation of vectors in null space.
-- `cubestratified, lcubestratified` now slightly more time-efficient for large data sets.
+- fixed bug in `cube`.
 
 ## [2.0.6] - 2024-02-15
 ### Fixed

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,5 +23,5 @@ URL:
     https://www.envisim.se/,
     https://github.com/envisim/BalancedSampling/
 NeedsCompilation: yes
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)

--- a/man/BalancedSampling.Rd
+++ b/man/BalancedSampling.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/BalancedSampling-package.R
 \docType{package}
 \name{BalancedSampling}
-\alias{BalancedSampling}
 \alias{BalancedSampling-package}
+\alias{BalancedSampling}
 \title{BalancedSampling: Balanced and Spatially Balanced Sampling}
 \description{
 Select balanced and spatially balanced probability samples in multi-dimensional

--- a/src/CubeClass.cc
+++ b/src/CubeClass.cc
@@ -100,7 +100,7 @@ void Cube::Init(
 
     for (size_t k = 0; k < pbalance; k++)
       amat[MatrixIdxCM(i, k, N)] =
-        xxbalance[MatrixIdxCM(i, k, pbalance)] / probabilities[i];
+        xxbalance[MatrixIdxCM(i, k, N)] / probabilities[i];
   }
 
   return;

--- a/src/IndexListClass.cc
+++ b/src/IndexListClass.cc
@@ -57,6 +57,10 @@ size_t IndexList::Length() {
   return len;
 }
 
+size_t IndexList::Capacity() {
+  return capacity;
+}
+
 void IndexList::Fill() {
   for (size_t i = 0; i < capacity; i++) {
     list[i] = i;
@@ -75,7 +79,6 @@ void IndexList::Reset() {
 void IndexList::Resize(const size_t t_len) {
   if (t_len > capacity) {
     throw std::range_error("(resize) Inadmissable value of len");
-    return;
   }
 
   len = t_len;
@@ -99,7 +102,6 @@ void IndexList::Shuffle() {
 void IndexList::Set(const size_t id) {
   if (id >= capacity) {
     throw std::range_error("(set) Inadmissible value of id");
-    return;
   }
 
   list[id] = id;
@@ -109,7 +111,6 @@ void IndexList::Set(const size_t id) {
 void IndexList::Add(const size_t id) {
   if (id >= capacity) {
     throw std::range_error("(add) Inadmissible value of id");
-    return;
   }
 
   // k must not be smaller then len, or it already exists
@@ -125,7 +126,6 @@ void IndexList::Add(const size_t id) {
 size_t IndexList::Get(const size_t k) {
   if (k >= len) {
     throw std::range_error("(get) Inadmissible value of k");
-    // return SIZE_MAX;
   }
 
   return list[k];
@@ -166,7 +166,6 @@ void IndexList::Erase(const size_t id) {
       "(erase, 1) Inadmissible value of id: " + std::to_string(id) +
       ", len: " + std::to_string(len)
     );
-    return;
   }
 
   size_t k = reverse[id];
@@ -177,18 +176,18 @@ void IndexList::Erase(const size_t id) {
       ", k: " + std::to_string(k) +
       ", len: " + std::to_string(len)
     );
-    return;
   }
 
   len -= 1;
+  reverse[id] = capacity;
 
   // Early return, no need to swap
-  if (k == len)
+  if (k == len) {
     return;
+  }
 
-  std::swap(list[k], list[len]);
+  list[k] = list[len];
   reverse[list[k]] = k;
-  reverse[list[len]] = len;
 
   return;
 }

--- a/src/IndexListClass.h
+++ b/src/IndexListClass.h
@@ -18,6 +18,7 @@ public:
   size_t* CopyList();
 
   size_t Length();
+  size_t Capacity();
   void Fill();
   void Reset();
   void Resize(const size_t);


### PR DESCRIPTION
Solving two reports regarding `cube` and `cubestratified` not working as intended. The first related to the rotation of the balancing matrix in `CubeClass`, the other related to the erasing of units in `IndexList`.